### PR TITLE
Added a Hangire Enqueue Extension

### DIFF
--- a/Enexure.MicroBus.Sagas.Infrastructure/Context/IMicrobusSagaContext.cs
+++ b/Enexure.MicroBus.Sagas.Infrastructure/Context/IMicrobusSagaContext.cs
@@ -1,0 +1,23 @@
+﻿// Assembly           : Enexure.MicroBus.Sagas.Infrastructure
+// Author              : Topsey
+// Created On        : 28/5/2017
+// Last Modified By : Ian
+// Last Modified On : 28/5/2017 at 4:21 PM
+// **************************************************************************
+// <summary></summary>
+
+using System;
+using System.Threading.Tasks;
+using Enexure.MicroBus.Sagas.Infrastructure.Model;
+using Microsoft.EntityFrameworkCore;
+
+namespace Enexure.MicroBus.Sagas.Infrastructure.Context
+{
+    public interface IMicrobusSagaContext: IDisposable
+    {
+        DbSet<MicrobusSaga> MicrobusSagas { get; set; }
+
+        int SaveChanges();
+        Task<int> SaveChangesAsync();
+    }
+}

--- a/Enexure.MicroBus.Sagas.Infrastructure/Context/MicrobusSagaContext.cs
+++ b/Enexure.MicroBus.Sagas.Infrastructure/Context/MicrobusSagaContext.cs
@@ -1,0 +1,63 @@
+﻿// Assembly           : Enexure.MicroBus.Sagas.Infrastructure
+// Author              : Topsey
+// Created On        : 28/5/2017
+// Last Modified By : Ian
+// Last Modified On : 28/5/2017 at 4:21 PM
+// **************************************************************************
+// <summary></summary>
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Enexure.MicroBus.Sagas.Infrastructure.Model;
+using Microsoft.EntityFrameworkCore;
+
+namespace Enexure.MicroBus.Sagas.Infrastructure.Context
+{
+    public class MicrobusSagaContext : DbContext, IMicrobusSagaContext, IDisposable
+    {
+        public MicrobusSagaContext(DbContextOptions<MicrobusSagaContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<MicrobusSaga> MicrobusSagas { get; set; }
+
+        public Task<int> SaveChangesAsync()
+        {
+            AddTimestamps();
+            return base.SaveChangesAsync();
+        }
+
+        public override int SaveChanges()
+        {
+            AddTimestamps();
+            return base.SaveChanges();
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+        }
+
+        private void AddTimestamps()
+        {
+            var entities = ChangeTracker.Entries()
+                .Where(x => x.Entity is IModificationHistory && (x.State == EntityState.Added));
+
+            foreach (var entity in entities)
+            {
+                if (entity.State == EntityState.Added)
+                {
+                    ((IModificationHistory) entity.Entity).CreatedAt = DateTime.UtcNow;
+                }
+                ((IModificationHistory) entity.Entity).IsDirty = false;
+            }
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            base.OnConfiguring(optionsBuilder);
+        }
+    }
+}

--- a/Enexure.MicroBus.Sagas.Infrastructure/Context/MicrobusSagaContext.cs
+++ b/Enexure.MicroBus.Sagas.Infrastructure/Context/MicrobusSagaContext.cs
@@ -19,6 +19,10 @@ namespace Enexure.MicroBus.Sagas.Infrastructure.Context
         public MicrobusSagaContext(DbContextOptions<MicrobusSagaContext> options)
             : base(options)
         {
+            
+
+            Database.SetInitializer(new CreateDatabaseIfNotExists<MicrobusSagaContext>());
+
         }
 
         public DbSet<MicrobusSaga> MicrobusSagas { get; set; }

--- a/Enexure.MicroBus.Sagas.Infrastructure/Enexure.MicroBus.Sagas.Infrastructure.csproj
+++ b/Enexure.MicroBus.Sagas.Infrastructure/Enexure.MicroBus.Sagas.Infrastructure.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Contains Saga Infrastructure addons for MicroBus</Description>
+    <VersionPrefix>1.0.0.1</VersionPrefix>
+    <Authors>Topsey</Authors>
+    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <AssemblyName>Enexure.MicroBus.Sagas.Infrastructure</AssemblyName>
+    <PackageId>Enexure.MicroBus.Sagas.Infrastructure</PackageId>
+    <PackageTags>MicroBus;Mediator;Saga;Bus</PackageTags>
+    <!--<PackageIconUrl>https://raw.github.com/Lavinski/Enexure.MicroBus/master/Logo.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/Lavinski/Enexure.MicroBus/</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/Lavinski/Enexure.MicroBus/blob/master/License.md</PackageLicenseUrl>-->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Enexure.MicroBus.Sagas\Enexure.MicroBus.Sagas.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.EntityFrameworkCore">
+      <HintPath>..\..\..\Users\Ian\.nuget\packages\microsoft.entityframeworkcore\1.1.1\lib\netstandard1.3\Microsoft.EntityFrameworkCore.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.EntityFrameworkCore.Relational">
+      <HintPath>..\..\..\Users\Ian\.nuget\packages\microsoft.entityframeworkcore.relational\1.1.1\lib\netstandard1.3\Microsoft.EntityFrameworkCore.Relational.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>
+

--- a/Enexure.MicroBus.Sagas.Infrastructure/Enexure.MicroBus.Sagas.Infrastructure.licenseheader
+++ b/Enexure.MicroBus.Sagas.Infrastructure/Enexure.MicroBus.Sagas.Infrastructure.licenseheader
@@ -1,0 +1,21 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+// Assembly           : %Project%
+// Author              : Topsey
+// Created On        : %CreationDay%/%CreationMonth%/%CreationYear%
+// Last Modified By : %UserName%
+// Last Modified On : %CurrentDay%/%CurrentMonth%/%CurrentYear% at %CurrentTime%
+// **************************************************************************
+// <summary></summary>
+
+extensions: .aspx .ascx
+extensions: .aspx .ascx
+<%-- 
+Copyright (c) 2011 rubicon IT GmbH
+--%>
+extensions: .vb
+'Sample license text.
+extensions:  .xml .config .xsd
+<!--
+Sample license text.
+-->

--- a/Enexure.MicroBus.Sagas.Infrastructure/Model/IModificationHistory.cs
+++ b/Enexure.MicroBus.Sagas.Infrastructure/Model/IModificationHistory.cs
@@ -1,0 +1,24 @@
+// Assembly           : Enexure.MicroBus.Sagas.Infrastructure
+// Author              : Topsey
+// Created On        : 28/5/2017
+// Last Modified By : Ian
+// Last Modified On : 28/5/2017 at 4:21 PM
+// **************************************************************************
+// <summary></summary>
+
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Enexure.MicroBus.Sagas.Infrastructure.Model
+{
+    public interface IModificationHistory
+    {
+         DateTime ExpireAt { get; set; }
+         DateTime CreatedAt { get; set; }
+
+         DateTime CompletedAt { get; set; }
+
+        [NotMapped]
+        bool IsDirty { get; set; }
+    }
+}

--- a/Enexure.MicroBus.Sagas.Infrastructure/Model/MicrobusSaga.cs
+++ b/Enexure.MicroBus.Sagas.Infrastructure/Model/MicrobusSaga.cs
@@ -21,7 +21,6 @@ namespace Enexure.MicroBus.Sagas.Infrastructure.Model
 
         public DateTime ExpireAt { get; set; }
         public DateTime CreatedAt { get; set; }
-
         public DateTime CompletedAt { get; set; }
         public bool IsDirty { get; set; }
     }

--- a/Enexure.MicroBus.Sagas.Infrastructure/Model/MicrobusSaga.cs
+++ b/Enexure.MicroBus.Sagas.Infrastructure/Model/MicrobusSaga.cs
@@ -1,0 +1,28 @@
+﻿// Assembly           : Enexure.MicroBus.Sagas.Infrastructure
+// Author              : Topsey
+// Created On        : 28/5/2017
+// Last Modified By : Ian
+// Last Modified On : 28/5/2017 at 4:21 PM
+// **************************************************************************
+// <summary></summary>
+
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Enexure.MicroBus.Sagas.Infrastructure.Model
+{
+   [Table("Microbus.Sagas")]
+    public class MicrobusSaga : IModificationHistory
+    {
+        public Guid Id { get; set; }
+
+        [Column(TypeName = "varbin(MAX)")]
+        public byte[] Saga { get; set; }
+
+        public DateTime ExpireAt { get; set; }
+        public DateTime CreatedAt { get; set; }
+
+        public DateTime CompletedAt { get; set; }
+        public bool IsDirty { get; set; }
+    }
+}

--- a/Enexure.MicroBus.sln
+++ b/Enexure.MicroBus.sln
@@ -39,9 +39,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Enexure.MicroBus.MicrosoftD
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Enexure.MicroBus.MicrosoftDependencyInjection.Tests", "src\Enexure.MicroBus.MicrosoftDependencyInjection.Tests\Enexure.MicroBus.MicrosoftDependencyInjection.Tests.csproj", "{9C9FB5A2-BA03-4EFF-8D0F-E53E48D107BC}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WZHi.Hangfire.Microbus.Extensions", "..\..\VsTfs WZHi\WZHi.Hangfire.Mediatr.Extensions\WZHi.Hangfire.Microbus.Extensions\WZHi.Hangfire.Microbus.Extensions.csproj", "{127FA623-0498-4D6B-9399-BCF7AA319909}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Hangfire", "Hangfire", "{5DB4A0D7-1F2C-47FD-8CA8-A6095B61DB46}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Enexure.MicroBus.Sagas.Infrastructure", "Enexure.MicroBus.Sagas.Infrastructure\Enexure.MicroBus.Sagas.Infrastructure.csproj", "{D4334BF2-5010-48B3-924D-468F1D23DD80}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WZHi.Hangfire.Microbus.Extensions", "src\WZHi.Hangfire.Microbus.Extensions\WZHi.Hangfire.Microbus.Extensions.csproj", "{6E05091D-782C-4AA8-8510-FDEE7DDC2EF0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -97,10 +99,14 @@ Global
 		{9C9FB5A2-BA03-4EFF-8D0F-E53E48D107BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9C9FB5A2-BA03-4EFF-8D0F-E53E48D107BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9C9FB5A2-BA03-4EFF-8D0F-E53E48D107BC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{127FA623-0498-4D6B-9399-BCF7AA319909}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{127FA623-0498-4D6B-9399-BCF7AA319909}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{127FA623-0498-4D6B-9399-BCF7AA319909}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{127FA623-0498-4D6B-9399-BCF7AA319909}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4334BF2-5010-48B3-924D-468F1D23DD80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4334BF2-5010-48B3-924D-468F1D23DD80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4334BF2-5010-48B3-924D-468F1D23DD80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4334BF2-5010-48B3-924D-468F1D23DD80}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E05091D-782C-4AA8-8510-FDEE7DDC2EF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E05091D-782C-4AA8-8510-FDEE7DDC2EF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E05091D-782C-4AA8-8510-FDEE7DDC2EF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E05091D-782C-4AA8-8510-FDEE7DDC2EF0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -121,6 +127,6 @@ Global
 		{ADB75E2F-8AC6-4FDD-B9BE-6AFBDE52EE02} = {2C0191A8-8BF9-486E-A837-0B23F44A7BE0}
 		{7CA1464D-7BC4-416F-A2F2-00CC93946730} = {ADB75E2F-8AC6-4FDD-B9BE-6AFBDE52EE02}
 		{9C9FB5A2-BA03-4EFF-8D0F-E53E48D107BC} = {ADB75E2F-8AC6-4FDD-B9BE-6AFBDE52EE02}
-		{127FA623-0498-4D6B-9399-BCF7AA319909} = {5DB4A0D7-1F2C-47FD-8CA8-A6095B61DB46}
+		{6E05091D-782C-4AA8-8510-FDEE7DDC2EF0} = {5DB4A0D7-1F2C-47FD-8CA8-A6095B61DB46}
 	EndGlobalSection
 EndGlobal

--- a/Enexure.MicroBus.sln
+++ b/Enexure.MicroBus.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Autofac", "Autofac", "{D6BA7654-EB91-459C-A729-801AE7B88174}"
 EndProject
@@ -35,9 +35,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Autofac", "Autofac", "{9F35
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MicrosoftDependencyInjection", "MicrosoftDependencyInjection", "{ADB75E2F-8AC6-4FDD-B9BE-6AFBDE52EE02}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Enexure.MicroBus.MicrosoftDependencyInjection", "src\Enexure.MicroBus.MicrosoftDependencyInjection\Enexure.MicroBus.MicrosoftDependencyInjection.csproj", "{7CA1464D-7BC4-416F-A2F2-00CC93946730}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Enexure.MicroBus.MicrosoftDependencyInjection", "src\Enexure.MicroBus.MicrosoftDependencyInjection\Enexure.MicroBus.MicrosoftDependencyInjection.csproj", "{7CA1464D-7BC4-416F-A2F2-00CC93946730}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Enexure.MicroBus.MicrosoftDependencyInjection.Tests", "src\Enexure.MicroBus.MicrosoftDependencyInjection.Tests\Enexure.MicroBus.MicrosoftDependencyInjection.Tests.csproj", "{9C9FB5A2-BA03-4EFF-8D0F-E53E48D107BC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Enexure.MicroBus.MicrosoftDependencyInjection.Tests", "src\Enexure.MicroBus.MicrosoftDependencyInjection.Tests\Enexure.MicroBus.MicrosoftDependencyInjection.Tests.csproj", "{9C9FB5A2-BA03-4EFF-8D0F-E53E48D107BC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WZHi.Hangfire.Microbus.Extensions", "..\..\VsTfs WZHi\WZHi.Hangfire.Mediatr.Extensions\WZHi.Hangfire.Microbus.Extensions\WZHi.Hangfire.Microbus.Extensions.csproj", "{127FA623-0498-4D6B-9399-BCF7AA319909}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Hangfire", "Hangfire", "{5DB4A0D7-1F2C-47FD-8CA8-A6095B61DB46}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -93,6 +97,10 @@ Global
 		{9C9FB5A2-BA03-4EFF-8D0F-E53E48D107BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9C9FB5A2-BA03-4EFF-8D0F-E53E48D107BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9C9FB5A2-BA03-4EFF-8D0F-E53E48D107BC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{127FA623-0498-4D6B-9399-BCF7AA319909}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{127FA623-0498-4D6B-9399-BCF7AA319909}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{127FA623-0498-4D6B-9399-BCF7AA319909}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{127FA623-0498-4D6B-9399-BCF7AA319909}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -113,5 +121,6 @@ Global
 		{ADB75E2F-8AC6-4FDD-B9BE-6AFBDE52EE02} = {2C0191A8-8BF9-486E-A837-0B23F44A7BE0}
 		{7CA1464D-7BC4-416F-A2F2-00CC93946730} = {ADB75E2F-8AC6-4FDD-B9BE-6AFBDE52EE02}
 		{9C9FB5A2-BA03-4EFF-8D0F-E53E48D107BC} = {ADB75E2F-8AC6-4FDD-B9BE-6AFBDE52EE02}
+		{127FA623-0498-4D6B-9399-BCF7AA319909} = {5DB4A0D7-1F2C-47FD-8CA8-A6095B61DB46}
 	EndGlobalSection
 EndGlobal

--- a/src/Enexure.MicroBus.Saga.Autofac.Tests/Enexure.MicroBus.Saga.Autofac.Tests.csproj
+++ b/src/Enexure.MicroBus.Saga.Autofac.Tests/Enexure.MicroBus.Saga.Autofac.Tests.csproj
@@ -4,7 +4,7 @@
     <Description>MicroBus.Sagas.Autofac.Tests</Description>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>Daniel Little</Authors>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <AssemblyName>Enexure.MicroBus.Saga.Autofac.Tests</AssemblyName>
     <PackageId>Enexure.MicroBus.Saga.Autofac.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Enexure.MicroBus.Sagas.Infrastructure\Enexure.MicroBus.Sagas.Infrastructure.csproj" />
     <ProjectReference Include="..\Enexure.MicroBus\Enexure.MicroBus.csproj" />
     <ProjectReference Include="..\Enexure.MicroBus.Autofac\Enexure.MicroBus.Autofac.csproj" />
     <ProjectReference Include="..\Enexure.MicroBus.InfrastructureContracts\Enexure.MicroBus.InfrastructureContracts.csproj" />
@@ -25,11 +26,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
-    <PackageReference Include="Autofac" Version="4.0.0-rc2-240" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
-    <PackageReference Include="FluentAssertions" Version="4.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170517-02" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="Autofac" Version="4.6.0" />
+    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
+    <PackageReference Include="FluentAssertions" Version="4.19.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Enexure.MicroBus.Saga.Autofac.Tests/TestSaga.cs
+++ b/src/Enexure.MicroBus.Saga.Autofac.Tests/TestSaga.cs
@@ -13,7 +13,9 @@ namespace Enexure.MicroBus.Saga.Autofac.Tests
 		public Guid Id { get; protected set; }
 		public bool IsCompleted { get; protected set; }
 
-		public async Task Handle(SagaStartingAEvent @event)
+	    public char[] IsNotCompleted { get; protected set; }
+
+        public async Task Handle(SagaStartingAEvent @event)
 		{
 			Id = @event.CorrelationId;
 		}

--- a/src/Enexure.MicroBus.Saga.Autofac.Tests/TestSagaRepository.cs
+++ b/src/Enexure.MicroBus.Saga.Autofac.Tests/TestSagaRepository.cs
@@ -2,16 +2,20 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Enexure.MicroBus.Sagas;
+using Enexure.MicroBus.Sagas.Infrastructure.Context;
+using Enexure.MicroBus.Sagas.Infrastructure.Model;
 
 namespace Enexure.MicroBus.Saga.Autofac.Tests
 {
 	public class TestSagaRepository : ISagaRepository<TestSaga>
 	{
-		Dictionary<Guid, TestSaga> sagas = new Dictionary<Guid, TestSaga>();
+	    private readonly MicrobusSagaContext _context;
+
+        Dictionary<Guid, TestSaga> sagas = new Dictionary<Guid, TestSaga>();
 
 		public Task CompleteAsync(TestSaga saga)
 		{
-			sagas.Remove(saga.Id);
+            sagas.Remove(saga.Id);
 			return Task.CompletedTask;
 		}
 

--- a/src/Enexure.MicroBus.Sagas/ISagaRepository.cs
+++ b/src/Enexure.MicroBus.Sagas/ISagaRepository.cs
@@ -4,8 +4,7 @@ using System.Threading.Tasks;
 
 namespace Enexure.MicroBus.Sagas
 {
-	public interface ISagaRepository<TSaga>
-		where TSaga : class, ISaga
+	public interface ISagaRepository<TSaga> where TSaga : class, ISaga
 	{
 		Task CreateAsync(TSaga saga);
 		Task UpdateAsync(TSaga saga);

--- a/src/WZHi.Hangfire.Microbus.Extensions/Extensions/HangfireMicorbusExtension.cs
+++ b/src/WZHi.Hangfire.Microbus.Extensions/Extensions/HangfireMicorbusExtension.cs
@@ -1,0 +1,41 @@
+﻿// Assembly           : WZHi.Hangfire.Microbus.Extensions
+// Author              : Topsey
+// Created On        : 21/5/2017
+// Last Modified By : Ian
+// Last Modified On : 24/5/2017 at 2:36 PM
+// **************************************************************************
+// <summary>Based on Derek Comartin article Background Commands with MediatR and Hangfire</summary>
+
+using Enexure.MicroBus;
+using Hangfire;
+using Hangfire.Common;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using WZHi.Hangfire.Microbus.Integration.Infrastructure;
+
+namespace WZHi.Hangfire.Microbus.Integration.Extensions
+{
+    public static class HangfireMicorbusExtension
+
+    {
+        public delegate HangfireMicrobusContext DatabaseContext();
+
+        public static HangfireMicrobusContext Context { get; set; }
+
+        public static IGlobalConfiguration UseMicrobus(this IGlobalConfiguration config, IMicroMediator mediator, HangfireMicrobusContext context)
+        {
+            context.Database.Migrate();
+
+            config.UseActivator(new MicrobusJobActivator(mediator, context));
+
+            JobHelper.SetSerializerSettings(new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.Objects
+            });
+
+            Context = context;
+
+            return config;
+        }
+    }
+}

--- a/src/WZHi.Hangfire.Microbus.Extensions/Extensions/HangfireMicrobusMediator.cs
+++ b/src/WZHi.Hangfire.Microbus.Extensions/Extensions/HangfireMicrobusMediator.cs
@@ -37,7 +37,7 @@ namespace WZHi.Hangfire.Microbus.Integration.Extensions
             {
                 try
                 {
-                    var data = await db.MicrobusRrequests.SingleAsync(s => s.Id == id);
+                    var data = await db.MicrobusRequests.SingleAsync(s => s.Id == id);
 
                     var request = JsonConvert.DeserializeObject<ICommand>(data.ToString(),
                         new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All });

--- a/src/WZHi.Hangfire.Microbus.Extensions/Extensions/HangfireMicrobusMediator.cs
+++ b/src/WZHi.Hangfire.Microbus.Extensions/Extensions/HangfireMicrobusMediator.cs
@@ -1,0 +1,54 @@
+﻿// Assembly           : WZHi.Hangfire.Microbus.Extensions
+// Author              : Topsey
+// Created On        : 21/5/2017
+// Last Modified By : Ian
+// Last Modified On : 24/5/2017 at 2:36 PM
+// **************************************************************************
+// <summary>Based on Derek Comartin article Background Commands with MediatR and Hangfire</summary>
+
+using System;
+using System.Threading.Tasks;
+using Enexure.MicroBus;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using WZHi.Hangfire.Microbus.Integration.Infrastructure;
+
+namespace WZHi.Hangfire.Microbus.Integration.Extensions
+{
+    public class HangfireMicrobusMediator
+    {
+        private readonly HangfireMicrobusContext _context;
+        private readonly IMicroMediator _mediator;
+
+        public HangfireMicrobusMediator(IMicroMediator mediator, HangfireMicrobusContext context)
+        {
+            _mediator = mediator;
+            _context = context;
+        }
+
+        public async Task SendCommandAsync(ICommand command)
+        {
+            await _mediator.SendAsync(command);
+        }
+
+        public async Task ProcessAsync(Guid id)
+        {
+            using (var db = HangfireMicorbusExtension.Context)
+            {
+                try
+                {
+                    var data = await db.MicrobusRrequests.SingleAsync(s => s.Id == id);
+
+                    var request = JsonConvert.DeserializeObject<ICommand>(data.ToString(),
+                        new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All });
+
+                    await _mediator.SendAsync(request).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException($"Request (id) not found.");
+                }
+            }
+        }
+    }
+}

--- a/src/WZHi.Hangfire.Microbus.Extensions/Extensions/MicrobusExtension.cs
+++ b/src/WZHi.Hangfire.Microbus.Extensions/Extensions/MicrobusExtension.cs
@@ -1,0 +1,54 @@
+﻿// Assembly           : WZHi.Hangfire.Microbus.Extensions
+// Author              : Topsey
+// Created On        : 21/5/2017
+// Last Modified By : Ian
+// Last Modified On : 24/5/2017 at 2:36 PM
+// **************************************************************************
+// <summary>Based on Derek Comartin article Background Commands with MediatR and Hangfire</summary>
+
+using System;
+using System.Threading.Tasks;
+using Enexure.MicroBus;
+using Hangfire;
+using Newtonsoft.Json;
+using WZHi.Hangfire.Microbus.Integration.Model;
+
+namespace WZHi.Hangfire.Microbus.Integration.Extensions
+{
+    public static class MicrobusExtension
+    {
+        public static void Enqueue(this IMicroMediator mediator, ICommand command)
+        {
+            BackgroundJob.Enqueue<HangfireMicrobusMediator>(m => m.SendCommandAsync(command));
+        }
+
+        public static void Enqueue(this IMicroMediator mediator,  TimeSpan delay, ICommand command)
+        {
+            BackgroundJob.Schedule<HangfireMicrobusMediator>(m => m.SendCommandAsync(command),delay);
+        }
+
+        public static void Enqueue(this IMicroMediator mediator, DateTimeOffset enqueueAt, ICommand command)
+        {
+            BackgroundJob.Schedule<HangfireMicrobusMediator>(m => m.SendCommandAsync(command), enqueueAt);
+        }
+
+        public static async Task Enqueue(this IMicroMediator mediator, Guid id, ICommand command)// todo add scheduling
+        {
+            using (var db = HangfireMicorbusExtension.Context)
+            {
+                await db.MicrobusRrequests.AddAsync(new MicrobusRequest
+                {
+                    Id = id,
+                    Body = JsonConvert.SerializeObject(command, new JsonSerializerSettings
+                    {
+                        TypeNameHandling = TypeNameHandling.All
+                    })
+                });
+
+                await db.SaveChangesAsync();
+
+                BackgroundJob.Enqueue<HangfireMicrobusMediator>(m => m.ProcessAsync(id));
+            }
+        }
+    }
+}

--- a/src/WZHi.Hangfire.Microbus.Extensions/Extensions/MicrobusExtension.cs
+++ b/src/WZHi.Hangfire.Microbus.Extensions/Extensions/MicrobusExtension.cs
@@ -36,7 +36,7 @@ namespace WZHi.Hangfire.Microbus.Integration.Extensions
         {
             using (var db = HangfireMicorbusExtension.Context)
             {
-                await db.MicrobusRrequests.AddAsync(new MicrobusRequest
+                await db.MicrobusRequests.AddAsync(new MicrobusRequest
                 {
                     Id = id,
                     Body = JsonConvert.SerializeObject(command, new JsonSerializerSettings

--- a/src/WZHi.Hangfire.Microbus.Extensions/Infrastructure/HangfireMicrobusContext.cs
+++ b/src/WZHi.Hangfire.Microbus.Extensions/Infrastructure/HangfireMicrobusContext.cs
@@ -1,0 +1,63 @@
+﻿// Assembly           : WZHi.Hangfire.Microbus.Extensions
+// Author              : Topsey
+// Created On        : 22/5/2017
+// Last Modified By : Ian
+// Last Modified On : 24/5/2017 at 2:36 PM
+// **************************************************************************
+// <summary>Based on Derek Comartin article Background Commands with MediatR and Hangfire</summary>
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using WZHi.Hangfire.Microbus.Integration.Model;
+
+namespace WZHi.Hangfire.Microbus.Integration.Infrastructure
+{
+    public class HangfireMicrobusContext : DbContext, IHangfireMicrobusContext, IDisposable
+    {
+        public HangfireMicrobusContext(DbContextOptions<HangfireMicrobusContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<MicrobusRequest> MicrobusRrequests { get; set; }
+
+        public Task<int> SaveChangesAsync()
+        {
+            AddTimestamps();
+            return base.SaveChangesAsync();
+        }
+
+        public override int SaveChanges()
+        {
+            AddTimestamps();
+            return base.SaveChanges();
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+        }
+
+        private void AddTimestamps()
+        {
+            var entities = ChangeTracker.Entries()
+                .Where(x => x.Entity is IModificationHistory && (x.State == EntityState.Added));
+
+            foreach (var entity in entities)
+            {
+                if (entity.State == EntityState.Added)
+                {
+                    ((IModificationHistory) entity.Entity).CreatedAt = DateTime.UtcNow;
+                }
+                ((IModificationHistory) entity.Entity).IsDirty = false;
+            }
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            base.OnConfiguring(optionsBuilder);
+        }
+    }
+}

--- a/src/WZHi.Hangfire.Microbus.Extensions/Infrastructure/HangfireMicrobusContext.cs
+++ b/src/WZHi.Hangfire.Microbus.Extensions/Infrastructure/HangfireMicrobusContext.cs
@@ -21,7 +21,7 @@ namespace WZHi.Hangfire.Microbus.Integration.Infrastructure
         {
         }
 
-        public DbSet<MicrobusRequest> MicrobusRrequests { get; set; }
+        public DbSet<MicrobusRequest> MicrobusRequests { get; set; }
 
         public Task<int> SaveChangesAsync()
         {

--- a/src/WZHi.Hangfire.Microbus.Extensions/Infrastructure/IHangfireMicrobusContext.cs
+++ b/src/WZHi.Hangfire.Microbus.Extensions/Infrastructure/IHangfireMicrobusContext.cs
@@ -15,7 +15,7 @@ namespace WZHi.Hangfire.Microbus.Integration.Infrastructure
 {
     public interface IHangfireMicrobusContext : IDisposable
     {
-        DbSet<MicrobusRequest> MicrobusRrequests { get; set; }
+        DbSet<MicrobusRequest> MicrobusRequests { get; set; }
 
         int SaveChanges();
         Task<int> SaveChangesAsync();

--- a/src/WZHi.Hangfire.Microbus.Extensions/Infrastructure/IHangfireMicrobusContext.cs
+++ b/src/WZHi.Hangfire.Microbus.Extensions/Infrastructure/IHangfireMicrobusContext.cs
@@ -1,0 +1,23 @@
+﻿// Assembly           : WZHi.Hangfire.Microbus.Extensions
+// Author              : Topsey
+// Created On        : 22/5/2017
+// Last Modified By : Ian
+// Last Modified On : 24/5/2017 at 2:36 PM
+// **************************************************************************
+// <summary>Based on Derek Comartin article Background Commands with MediatR and Hangfire</summary>
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using WZHi.Hangfire.Microbus.Integration.Model;
+
+namespace WZHi.Hangfire.Microbus.Integration.Infrastructure
+{
+    public interface IHangfireMicrobusContext : IDisposable
+    {
+        DbSet<MicrobusRequest> MicrobusRrequests { get; set; }
+
+        int SaveChanges();
+        Task<int> SaveChangesAsync();
+    }
+}

--- a/src/WZHi.Hangfire.Microbus.Extensions/MicrobusJobActivator.cs
+++ b/src/WZHi.Hangfire.Microbus.Extensions/MicrobusJobActivator.cs
@@ -1,0 +1,33 @@
+﻿// Assembly           : WZHi.Hangfire.Microbus.Extensions
+// Author              : Topsey
+// Created On        : 21/5/2017
+// Last Modified By : Ian
+// Last Modified On : 24/5/2017 at 2:36 PM
+// **************************************************************************
+// <summary>Based on Derek Comartin article Background Commands with MediatR and Hangfire</summary>
+
+using System;
+using Enexure.MicroBus;
+using Hangfire;
+using WZHi.Hangfire.Microbus.Integration.Extensions;
+using WZHi.Hangfire.Microbus.Integration.Infrastructure;
+
+namespace WZHi.Hangfire.Microbus.Integration
+{
+    public class MicrobusJobActivator : JobActivator
+    {
+        private readonly HangfireMicrobusContext _context;
+        private readonly IMicroMediator _mediator;
+
+        public MicrobusJobActivator(IMicroMediator mediator, HangfireMicrobusContext context)
+        {
+            _mediator = mediator;
+            _context = context;
+        }
+
+        public override object ActivateJob(Type type)
+        {
+            return new HangfireMicrobusMediator(_mediator, _context);
+        }
+    }
+}

--- a/src/WZHi.Hangfire.Microbus.Extensions/Model/IModificationHistory.cs
+++ b/src/WZHi.Hangfire.Microbus.Extensions/Model/IModificationHistory.cs
@@ -1,0 +1,21 @@
+// Assembly           : WZHi.Hangfire.Microbus.Extensions
+// Author              : Topsey
+// Created On        : 22/5/2017
+// Last Modified By : Ian
+// Last Modified On : 24/5/2017 at 2:36 PM
+// **************************************************************************
+// <summary>Based on Derek Comartin article Background Commands with MediatR and Hangfire</summary>
+
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace WZHi.Hangfire.Microbus.Integration.Model
+{
+    public interface IModificationHistory
+    {
+        DateTime CreatedAt { get; set; }
+
+        [NotMapped]
+        bool IsDirty { get; set; }
+    }
+}

--- a/src/WZHi.Hangfire.Microbus.Extensions/Model/MicrobusRequest.cs
+++ b/src/WZHi.Hangfire.Microbus.Extensions/Model/MicrobusRequest.cs
@@ -1,0 +1,32 @@
+﻿// Assembly           : WZHi.Hangfire.Microbus.Extensions
+// Author              : Topsey
+// Created On        : 22/5/2017
+// Last Modified By : Ian
+// Last Modified On : 24/5/2017 at 2:36 PM
+// **************************************************************************
+// <summary>Based on Derek Comartin article Background Commands with MediatR and Hangfire</summary>
+
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace WZHi.Hangfire.Microbus.Integration.Model
+{
+    // note I still prefer the job activator rather than this method of placing directly in the db to be reread by hangfire
+
+    [Table("Microbus.Request")]
+    public class MicrobusRequest : IModificationHistory
+    {
+        public Guid Id { get; set; }
+
+        [Column(TypeName = "varchar(MAX)")]
+        public string Body { get; set; }
+
+        public string StateName { get; set; }
+
+        public DateTime ExpireAt { get; set; }
+        public DateTime CreatedAt { get; set; }
+
+        public DateTime CompletedAt { get; set; }
+        public bool IsDirty { get; set; }
+    }
+}

--- a/src/WZHi.Hangfire.Microbus.Extensions/WZHi.Hangfire.Micorbus.Extensions.licenseheader
+++ b/src/WZHi.Hangfire.Microbus.Extensions/WZHi.Hangfire.Micorbus.Extensions.licenseheader
@@ -1,0 +1,21 @@
+﻿extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+// Assembly           : %Project%
+// Author              : Topsey
+// Created On        : %CreationDay%/%CreationMonth%/%CreationYear%
+// Last Modified By : %UserName%
+// Last Modified On : %CurrentDay%/%CurrentMonth%/%CurrentYear% at %CurrentTime%
+// **************************************************************************
+// <summary>Based on Derek Comartin article Background Commands with MediatR and Hangfire</summary>
+
+extensions: .aspx .ascx
+extensions: .aspx .ascx
+<%-- 
+Copyright (c) 2011 rubicon IT GmbH
+--%>
+extensions: .vb
+'Sample license text.
+extensions:  .xml .config .xsd
+<!--
+Sample license text.
+-->

--- a/src/WZHi.Hangfire.Microbus.Extensions/WZHi.Hangfire.Microbus.Extensions.csproj
+++ b/src/WZHi.Hangfire.Microbus.Extensions/WZHi.Hangfire.Microbus.Extensions.csproj
@@ -16,15 +16,10 @@
   <ItemGroup>
     <PackageReference Include="Enexure.MicroBus" Version="3.5.0" />
     <PackageReference Include="Hangfire" Version="1.6.12" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.2" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="Microsoft.EntityFrameworkCore">
-      <HintPath>..\..\..\Users\Ian\.nuget\packages\microsoft.entityframeworkcore\1.1.1\lib\netstandard1.3\Microsoft.EntityFrameworkCore.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.EntityFrameworkCore.Relational">
-      <HintPath>..\..\..\Users\Ian\.nuget\packages\microsoft.entityframeworkcore.relational\1.1.1\lib\netstandard1.3\Microsoft.EntityFrameworkCore.Relational.dll</HintPath>
-    </Reference>
-  </ItemGroup>
+
 
 </Project>

--- a/src/WZHi.Hangfire.Microbus.Extensions/WZHi.Hangfire.Microbus.Extensions.csproj
+++ b/src/WZHi.Hangfire.Microbus.Extensions/WZHi.Hangfire.Microbus.Extensions.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Description>Hangfire Microbus Extension</Description>
+    <RootNamespace>WZHi.Hangfire.Microbus.Integration</RootNamespace>
+    <PackageId>WZHi.Hangfire.Microbus.Extension</PackageId>
+    <Authors>WZHi.Hangfire.Microbus.Extension</Authors>
+    <Company>WZHi.Hangfire.Microbus.Extension</Company>
+    <Product>WZHi.Hangfire.Microbus.Extension</Product>
+    <Version>1.0.0.4</Version>
+    <Copyright>WZHi</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Enexure.MicroBus" Version="3.5.0" />
+    <PackageReference Include="Hangfire" Version="1.6.12" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.EntityFrameworkCore">
+      <HintPath>..\..\..\Users\Ian\.nuget\packages\microsoft.entityframeworkcore\1.1.1\lib\netstandard1.3\Microsoft.EntityFrameworkCore.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.EntityFrameworkCore.Relational">
+      <HintPath>..\..\..\Users\Ian\.nuget\packages\microsoft.entityframeworkcore.relational\1.1.1\lib\netstandard1.3\Microsoft.EntityFrameworkCore.Relational.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Hi Daniel,

As your mediator works in UWP and MediatR does not yet, I am using a mediator in a web api with Hangfire. I wanted to use the same mediator throughout so I expanded from Derek Comartin example integrating MediatR with Hangfire to integrate with Microbus. I have added a Microbus version to the fork.

If using MicrosoftDependencyInjection wire up the startup file as below

 services.AddScoped<HangfireMicrobusMediator>();
            services.AddSingleton<IMicroMediator, MicroMediator>();

            var busBuilder = new BusBuilder()
                .RegisterCommandHandler<MicrobusEnaabledClass, MicrobusEnaabledClassHandler>();

            services.RegisterMicroBus(busBuilder);

            var migrationsAssembly = typeof(Startup).GetTypeInfo().Assembly.GetName().Name;

            services.AddDbContext<HangfireMicrobusContext>(options =>
                options.UseSqlServer(connectionStringH, options2 =>
                    options2.MigrationsAssembly(migrationsAssembly)));

            var serviceProvider = services.BuildServiceProvider();
            var microbusMediator = serviceProvider.GetService<IMicroMediator>();

            var ctx = serviceProvider.GetService<HangfireMicrobusContext>();

            GlobalConfiguration.Configuration
                .UseColouredConsoleLogProvider()
                .UseMicrobus(microbusMediator, ctx)
                .UseSqlServerStorage(connectionStringH);

Then use 

var commandMb = new MicrobusEnaabledClass();
 _mediator.Enqueue(tim,commandMb);

I have overloaded the Enqueue to include a delay and action at a set time.

There is a method to save the Enqueue to the Hangfire database as well but I prefer the direct approach.

Look forward to your comments.

Ian.
